### PR TITLE
Build and test cli and extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore CLI
+        working-directory: cli.insightor
+        run: dotnet restore Insightor/Insightor.csproj | cat
+
+      - name: Build CLI (Release)
+        working-directory: cli.insightor
+        run: dotnet build Insightor/Insightor.csproj --configuration Release --no-restore | cat
+
+      - name: Run unit tests
+        working-directory: cli.insightor
+        run: dotnet test Insightor.Tests/Insightor.Tests.csproj --configuration Release --no-build --verbosity normal | cat
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install extension dependencies
+        working-directory: code.insightor/insightor
+        run: npm ci | cat
+
+      - name: Compile VS Code extension
+        working-directory: code.insightor/insightor
+        run: npm run --silent compile | cat
+


### PR DESCRIPTION
Add a GitHub Actions CI workflow to build the .NET CLI, run its unit tests, and compile the VS Code extension.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b46db06-5d9f-434b-b308-de566e390e50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b46db06-5d9f-434b-b308-de566e390e50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a CI workflow that builds and tests the .NET CLI and compiles the VS Code extension on pushes and PRs.
> 
> - **CI (GitHub Actions)**: Add `.github/workflows/ci.yml`
>   - Triggers: `push` to `main`/`master` and all `pull_request`s
>   - Job `build-and-test` on `ubuntu-latest`:
>     - .NET 9 setup; restore, build (Release), and run unit tests for `cli.insightor/Insightor/Insightor.csproj` and `cli.insightor/Insightor.Tests/Insightor.Tests.csproj`
>     - Node.js 22 setup; `npm ci` and compile VS Code extension in `code.insightor/insightor`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a91e0bd4842b998ba5824a967939c374ccd6d1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->